### PR TITLE
Unify groupId for off-chain groups

### DIFF
--- a/apps/api/src/app/groups/dto/create-group.dto.ts
+++ b/apps/api/src/app/groups/dto/create-group.dto.ts
@@ -6,10 +6,17 @@ import {
     Length,
     Min,
     MinLength,
-    NotContains
+    NotContains,
+    IsNumberString
 } from "class-validator"
 
 export class CreateGroupDto {
+    @IsString()
+    @IsOptional()
+    @Length(32)
+    @IsNumberString()
+    readonly id?: string
+
     @IsString()
     @Length(1, 50)
     @NotContains("admin-groups")

--- a/apps/api/src/app/groups/entities/group.entity.ts
+++ b/apps/api/src/app/groups/entities/group.entity.ts
@@ -4,17 +4,17 @@ import {
     Entity,
     Index,
     OneToMany,
-    PrimaryGeneratedColumn
+    PrimaryColumn,
 } from "typeorm"
 import { Member } from "./member.entity"
 
 @Entity("groups")
 export class Group {
-    @PrimaryGeneratedColumn()
-    id: number
+    @PrimaryColumn({ type: 'numeric', precision: 32, scale: 0 })
+    @Index({ unique: true })
+    id: string
 
     @Column()
-    @Index({ unique: true })
     name: string
 
     @Column()

--- a/apps/api/src/app/groups/entities/group.entity.ts
+++ b/apps/api/src/app/groups/entities/group.entity.ts
@@ -4,13 +4,13 @@ import {
     Entity,
     Index,
     OneToMany,
-    PrimaryColumn,
+    PrimaryColumn
 } from "typeorm"
 import { Member } from "./member.entity"
 
 @Entity("groups")
 export class Group {
-    @PrimaryColumn({ type: 'numeric', precision: 32, scale: 0 })
+    @PrimaryColumn({ type: "numeric", precision: 32, scale: 0 })
     @Index({ unique: true })
     id: string
 

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -41,8 +41,7 @@ export class GroupsService {
 
             /* istanbul ignore next */
             for (const group of groups) {
-                const groupId = BigInt(id(group.name))
-                const cachedGroup = new CachedGroup(groupId, group.treeDepth)
+                const cachedGroup = new CachedGroup(group.id, group.treeDepth)
 
                 cachedGroup.addMembers(group.members.map((m) => m.id))
 
@@ -62,10 +61,13 @@ export class GroupsService {
      * @returns Created group.
      */
     async createGroup(
-        { name, description, treeDepth, tag }: CreateGroupDto,
+        { id: groupId, name, description, treeDepth, tag }: CreateGroupDto,
         admin: string
     ): Promise<Group> {
+        const _groupId = groupId || BigInt((id(name + admin))).toString().slice(0, 32)
+
         const group = this.groupRepository.create({
+            id : _groupId,
             name,
             description,
             treeDepth,
@@ -154,7 +156,7 @@ export class GroupsService {
         )
 
         this.updatedGroups.push({
-            id: BigInt(id(group.name)),
+            id: BigInt(group.id),
             fingerprint: BigInt(cachedGroup.root)
         })
 
@@ -240,6 +242,7 @@ export class GroupsService {
      */
     /* istanbul ignore next */
     private async updateContractGroups(period = 60): Promise<void> {
+        console.log("updateContractGroups", this.schedulerRegistry.getTimeouts().length)
         if (this.schedulerRegistry.getTimeouts().length === 0) {
             const callback = async () => {
                 const tx = await zkGroups.updateGroups(this.updatedGroups)

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -64,10 +64,14 @@ export class GroupsService {
         { id: groupId, name, description, treeDepth, tag }: CreateGroupDto,
         admin: string
     ): Promise<Group> {
-        const _groupId = groupId || BigInt((id(name + admin))).toString().slice(0, 32)
+        const _groupId =
+            groupId ||
+            BigInt(id(name + admin))
+                .toString()
+                .slice(0, 32)
 
         const group = this.groupRepository.create({
-            id : _groupId,
+            id: _groupId,
             name,
             description,
             treeDepth,
@@ -242,7 +246,6 @@ export class GroupsService {
      */
     /* istanbul ignore next */
     private async updateContractGroups(period = 60): Promise<void> {
-        console.log("updateContractGroups", this.schedulerRegistry.getTimeouts().length)
         if (this.schedulerRegistry.getTimeouts().length === 0) {
             const callback = async () => {
                 const tx = await zkGroups.updateGroups(this.updatedGroups)

--- a/apps/dashboard/src/components/create-group-modal.tsx
+++ b/apps/dashboard/src/components/create-group-modal.tsx
@@ -148,7 +148,7 @@ export default function CreateGroupModal({
                                     <FormLabel>Name</FormLabel>
                                     <Input
                                         value={_groupName}
-                                        maxLength={31}
+                                        maxLength={isOnChainGroup ? 31 : 100}
                                         onChange={(e) =>
                                             setGroupName(e.target.value)
                                         }


### PR DESCRIPTION
## Description

- Use same ID for off-chain groups in DB and Smart contract
- Set off-chain group limit to 100 in UI

## Related Issue

#139 

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

## Other information

DB schema is changed. No migration is provided now.
Remove all tables and let TypeORM recreate the tables.
